### PR TITLE
fix: Respect client's preferred encoding when possible

### DIFF
--- a/tests/test_feature_manager.py
+++ b/tests/test_feature_manager.py
@@ -240,6 +240,19 @@ def server_capabilities(**kwargs):
                     ]
                 )
             ),
+            server_capabilities(position_encoding=lsp.PositionEncodingKind.Utf8),
+        ),
+        (
+            lsp.INITIALIZE,
+            None,
+            lsp.ClientCapabilities(
+                general=lsp.GeneralClientCapabilities(
+                    position_encodings=[
+                        lsp.PositionEncodingKind.Utf32,
+                        lsp.PositionEncodingKind.Utf8,
+                    ]
+                )
+            ),
             server_capabilities(position_encoding=lsp.PositionEncodingKind.Utf32),
         ),
         (


### PR DESCRIPTION
Previously, `pygls` would always use `UTF-16` except when the client tried to hide the fact that it supports `UTF-16` (which the LSP spec requires it to do in all cases). Now, `pygls` will choose the editor's preferred encoding.

When it is `UTF-32`, `pygls` saves a bit of computation in most position codec related operations (`X_to_client_units` + `client_num_units` are faster, `X_from_client_units` is about the same), which is great. When it is `UTF-16` or `UTF-8`, the computational load is about the same.

Closes: #445

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

[commit messages]: https://conventionalcommits.org/
